### PR TITLE
Add IA2_ROLE_BLOCK_QUOTE role.

### DIFF
--- a/api/AccessibleRole.idl
+++ b/api/AccessibleRole.idl
@@ -4,7 +4,7 @@
  *
  *  IAccessible2 IDL Specification
  *
- *  Copyright (c) 2007, 2013, 2018 Linux Foundation
+ *  Copyright (c) 2007-2018 Linux Foundation
  *  Copyright (c) 2006 IBM Corporation
  *  Copyright (c) 2000, 2006 Sun Microsystems, Inc.
  *  All rights reserved.
@@ -312,5 +312,8 @@ enum IA2Role {
   /** Content previously inserted or proposed for insertion, e.g. in revision
    history or a content view providing suggestions from reviewers.
   */
-  IA2_ROLE_CONTENT_INSERTION
+  IA2_ROLE_CONTENT_INSERTION,
+
+  /// A section of content that is quoted from another source.
+  IA2_ROLE_BLOCK_QUOTE
 };


### PR DESCRIPTION
Currently, IA2 clients detect web blockquote elements using the "tag" object attribute, but this is ugly at best.
Furthermore, this method cannot be used to detect the new ARIA blockquote role.
Thus, we need a dedicated IA2 role.