### PR TITLE
Fix compilation errors of IAccessibleTextSelectionContainer

### DIFF
--- a/api/AccessibleTextSelectionContainer.idl
+++ b/api/AccessibleTextSelectionContainer.idl
@@ -82,7 +82,7 @@ typedef struct IA2TextSelection {
   long startOffset;
   IAccessibleText* endObj;
   long endOffset;
-  bool startIsActive;
+  boolean startIsActive;
 } IA2TextSelection;
 
 /**

--- a/api/IA2TypeLibrary.idl
+++ b/api/IA2TypeLibrary.idl
@@ -87,6 +87,7 @@ library IAccessible2Lib
     interface IAccessibleTableCell;
     interface IAccessibleText;
     interface IAccessibleText2;
+	IAccessibleTextSelectionContainer;
     interface IAccessibleValue;
     enum IA2CoordinateType;
     enum IA2EventID;

--- a/api/IA2TypeLibrary.idl
+++ b/api/IA2TypeLibrary.idl
@@ -87,7 +87,7 @@ library IAccessible2Lib
     interface IAccessibleTableCell;
     interface IAccessibleText;
     interface IAccessibleText2;
-	IAccessibleTextSelectionContainer;
+	interface IAccessibleTextSelectionContainer;
     interface IAccessibleValue;
     enum IA2CoordinateType;
     enum IA2EventID;


### PR DESCRIPTION
fixes #18 

## Issue
* The IAccessible2 IDL files could not be compiled due to a syntax error. 'bool' does not exist.
* IAccessibleTextSelectionContainer was missing from the resulting type library.

## Fix
* ia2TextSelection struct's startIsActive member used 'bool' as its data type. this does not exist in idl. This has been changed to 'boolean'. 
 * IAccessibleTextSelectionContainer has been declaired in the type library section, ensuring that this interface is included in the type library.

## Testing
Upgraded NVDA to include IAccessible2 with IAccessibleTextSelectionContainer. Ensured that IAccessibleTextSelectionContainer appeared in NVDA's COM interfaces.

Signed-off-by: Michael Curran <mick@nvaccess.org>
