### PR TITLE
Remove reference to IAccessible2_3 from IA2TypeLibrary.idl.

### DIFF
--- a/api/IA2TypeLibrary.idl
+++ b/api/IA2TypeLibrary.idl
@@ -71,7 +71,6 @@ library IAccessible2Lib
     importlib ("oleacc.dll");
     interface IAccessible2;
     interface IAccessible2_2;
-    interface IAccessible2_3;
     interface IAccessibleAction;
     interface IAccessibleApplication;
     interface IAccessibleComponent;


### PR DESCRIPTION
When IAccessibleTextSelectionContainer was added (#17), IAccessible2_3 was deprecated and removed from the merged IDL built by concatidl.sh. If it's not in the merged IDL, it shouldn't be referenced in the type library. midl doesn't seem to complain about this, but widl (MinGW) does.