### PR TITLE
Update no longer working links

### DIFF
--- a/api/Accessible2.idl
+++ b/api/Accessible2.idl
@@ -145,7 +145,7 @@
  
   %IAccessible2 is a trademark of the Linux Foundation. The %IAccessible2 
   mark may be used in accordance with the
-  <a href="http://www.linuxfoundation.org/collaborate/workgroups/accessibility/trademark-policy">
+  <a href="https://www.linuxfoundation.org/legal/trademark-usage">
   Linux Foundation Trademark Policy</a> to indicate compliance with the %IAccessible2 specification. 
 
  @page _generalInfo General Information 

--- a/api/Accessible2_2.idl
+++ b/api/Accessible2_2.idl
@@ -77,7 +77,7 @@ interface IAccessible2_2 : IAccessible2
    @retval E_INVALIDARG if bad [in] passed.
    @note The output value is a VARIANT.  Typically it will be a VT_BSTR, but there
      are some cases where it will be a VT_I4 or VT_BOOL.  Refer to the <a href=
-     "http://www.linuxfoundation.org/collaborate/workgroups/accessibility/iaccessible2/objectattributesIAccessible2">
+     "https://wiki.linuxfoundation.org/accessibility/iaccessible2/objectattributes">
      Object Attributes specification</a> for more information.
   */
   [propget] HRESULT attribute


### PR DESCRIPTION
Update link to Object Attributes specification

The old link no longer works and leads to a
404 "Page Not Found" page.

---------

Update link to Linux Foundation Trademark Policy

The previous link now results in a
404 "Page Not Found" error.

Update to a working one [1], which also
contains another link to a list of registered
Linux Foundation tradmarks [2] that includes IAccessible2.

[1] https://www.linuxfoundation.org/legal/trademark-usage -
[2] https://www.linuxfoundation.org/legal/trademarks?hsLang=en
