### PR TITLE
Add text/object attributes spec from LinuxFoundation wiki

### DIFF
--- a/spec/objectattributes.md
+++ b/spec/objectattributes.md
@@ -1,63 +1,63 @@
-======iaccessible2/objectattributes======
+# IAccessible2 Object Attributes
 
- **Object Attributes**\\
-=====Contents=====
+## General Information
 
-  * [[https://www.linuxfoundation.org/#General_Information|1 General Information]]
-    * [[https://www.linuxfoundation.org/#Referenced_Specifications|1.1 Referenced Specifications]]
-    * [[https://www.linuxfoundation.org/#CSS2_values_information|1.2 CSS2 values information]]
-    * [[https://www.linuxfoundation.org/#Formating|1.3 Formating]]
-  * [[https://www.linuxfoundation.org/#Attributes|2 Attributes]]
-    * [[https://www.linuxfoundation.org/#List|2.1 List]]
-      * [[https://www.linuxfoundation.org/#List_Subattributes|2.1.1 List Subattributes]]
-    * [[https://www.linuxfoundation.org/#Paragraph|2.2 Paragraph]]
+### Referenced Specifications
 
-===== General Information=====
-==== Referenced Specifications====
+  *  [ODF v1.1](http://docs.oasis-open.org/office/v1.1/OS/OpenDocument-v1.1-html/OpenDocument-v1.1.html)
+  *  [CSS2](http://www.w3.org/TR/REC-CSS2/)
 
-  *  [[http://docs.oasis-open.org/office/v1.1/OS/OpenDocument-v1.1-html/OpenDocument-v1.1.html|ODF v1.1]]
-  *  [[http://www.w3.org/TR/REC-CSS2/|CSS2]]
-==== CSS2 values information====
+### CSS2 values information
 
-  *  [[http://www.w3.org/TR/REC-CSS2/syndata.html#value-def-length|<length>]]
-  *  [[http://www.w3.org/TR/REC-CSS2/syndata.html#value-def-percentage|<percentage>]]
-  *  [[http://www.w3.org/TR/REC-CSS2/syndata.html#strings|<string>]]
-  *  [[http://www.w3.org/TR/REC-CSS2/syndata.html#q13|<integer>]]
-==== Formating====
+  *  [\<length\>](http://www.w3.org/TR/REC-CSS2/syndata.html#value-def-length)
+  *  [\<percentage\>](http://www.w3.org/TR/REC-CSS2/syndata.html#value-def-percentage)
+  *  [\<string\>](http://www.w3.org/TR/REC-CSS2/syndata.html#strings)
+  *  [\<integer\>](http://www.w3.org/TR/REC-CSS2/syndata.html#q13)
 
-  *  The proper format for the attributes is \\  '' "attribute:value;attribute:subattribute=subvalue,subattribute=subvalue;" ''
+### Formating
+
+  *  The proper format for the attributes is `"attribute:value;attribute:subattribute=subvalue,subattribute=subvalue;"`
   *  These characters need to be escaped with a backslash:  backslash, colon, comma, equals, and semicolon.
   *  Attribute strings must always end with a semicolon.
-===== Attributes=====
-==== List====
+
+## Attributes
+
+### List
 
 Bulleted and numbered lists have been implemented in two different ways in IAccessible2 implementations.
 
 In versions 2 and later of IBM Lotus Symphony the list items are objects of role IA2_ROLE_PARAGRAPH; each of those paragraph objects implements IAccessible2::attributes; one of the attributes is the list attribute described below.  For these list items IAccessibleText exposes the contents after the non-editable prefix string.  The prefix string is in the form of a bullet character, a numbering prefix string, or an image.  The reason for this separation of access mechanisms is because the caret is movable through the list text but not through the prefix text.
 
 In Firefox the full string including the prefix is provided via IAccessibleText::text and the "auto-generated" text attribute is used for the string of characters representing the list prefix.
-^ Name^ Values^ Comments^ Reference^
-| list| level=[[http://www.w3.org/TR/REC-CSS2/syndata.html#q13|<integer>]], style=[[http://docs.oasis-open.org/office/v1.1/OS/OpenDocument-v1.1-html/OpenDocument-v1.1.html#outline:14.10.3.Bullet_Level_Style|bullet]], [[http://docs.oasis-open.org/office/v1.1/OS/OpenDocument-v1.1-html/OpenDocument-v1.1.html#outline:14.10.2.Number_Level_Style|number]], [[http://docs.oasis-open.org/office/v1.1/OS/OpenDocument-v1.1-html/OpenDocument-v1.1.html#outline:14.10.4.Image_Level_Style|image]], prefix=[[http://www.w3.org/TR/REC-CSS2/syndata.html#strings|<string>]]| [[http://www.w3.org/TR/REC-CSS2/syndata.html#q13|<integer>]] must be positive.| [[http://docs.oasis-open.org/office/v1.1/OS/OpenDocument-v1.1-html/OpenDocument-v1.1.html#outline:14.10.List_Style|ODF Specification  14.10]]|
-=== List Subattributes===
-^ Name^ Values^ Comments^ Reference^
-| level| [[http://www.w3.org/TR/REC-CSS2/syndata.html#q13|<integer>]]| [[http://www.w3.org/TR/REC-CSS2/syndata.html#q13|<integer>]] must be positive.|[[http://docs.oasis-open.org/office/v1.1/OS/OpenDocument-v1.1-html/OpenDocument-v1.1.html#outline:14.10.1.Common_List-Level_Style_Attributes|ODF Specification  14.10.1]]|
-| style| [[http://docs.oasis-open.org/office/v1.1/OS/OpenDocument-v1.1-html/OpenDocument-v1.1.html#outline:14.10.3.Bullet_Level_Style|bullet]], [[http://docs.oasis-open.org/office/v1.1/OS/OpenDocument-v1.1-html/OpenDocument-v1.1.html#outline:14.10.2.Number_Level_Style|number]], [[http://docs.oasis-open.org/office/v1.1/OS/OpenDocument-v1.1-html/OpenDocument-v1.1.html#outline:14.10.4.Image_Level_Style|image]]| Specifies the style of the list.| [[http://docs.oasis-open.org/office/v1.1/OS/OpenDocument-v1.1-html/OpenDocument-v1.1.html#outline:14.10.List_Style|ODF Specification  14.10]]|
-| prefix| [[http://www.w3.org/TR/REC-CSS2/syndata.html#strings|<string>]]| The prefix is inserted in front of the text.  The prefix contains a number (with any leading or trailing punctuation such as leading and/or trailing parens and/or a trailing period), or a bullet character, or the word "graphic".
 
-\\
-==== Paragraph====
+|Name|Values|Comments|Reference|
+|---|---|---|---|
+| list| level=[\<integer\>](http://www.w3.org/TR/REC-CSS2/syndata.html#q13), style=[bullet](http://docs.oasis-open.org/office/v1.1/OS/OpenDocument-v1.1-html/OpenDocument-v1.1.html#outline:14.10.3.Bullet_Level_Style), [number](http://docs.oasis-open.org/office/v1.1/OS/OpenDocument-v1.1-html/OpenDocument-v1.1.html#outline:14.10.2.Number_Level_Style), [image](http://docs.oasis-open.org/office/v1.1/OS/OpenDocument-v1.1-html/OpenDocument-v1.1.html#outline:14.10.4.Image_Level_Style), prefix=[\<string\>](http://www.w3.org/TR/REC-CSS2/syndata.html#strings)| [\<integer\>](http://www.w3.org/TR/REC-CSS2/syndata.html#q13) must be positive.| [ODF Specification  14.10](http://docs.oasis-open.org/office/v1.1/OS/OpenDocument-v1.1-html/OpenDocument-v1.1.html#outline:14.10.List_Style)|
+
+#### List Subattributes
+
+|Name|Values|Comments|Reference|
+|---|---|---|---|
+| level| [\<integer\>](http://www.w3.org/TR/REC-CSS2/syndata.html#q13)| [\<integer\>](http://www.w3.org/TR/REC-CSS2/syndata.html#q13) must be positive.|[ODF Specification  14.10.1](http://docs.oasis-open.org/office/v1.1/OS/OpenDocument-v1.1-html/OpenDocument-v1.1.html#outline:14.10.1.Common_List-Level_Style_Attributes)|
+| style| [bullet](http://docs.oasis-open.org/office/v1.1/OS/OpenDocument-v1.1-html/OpenDocument-v1.1.html#outline:14.10.3.Bullet_Level_Style), [number](http://docs.oasis-open.org/office/v1.1/OS/OpenDocument-v1.1-html/OpenDocument-v1.1.html#outline:14.10.2.Number_Level_Style), [image](http://docs.oasis-open.org/office/v1.1/OS/OpenDocument-v1.1-html/OpenDocument-v1.1.html#outline:14.10.4.Image_Level_Style)| Specifies the style of the list.| [ODF Specification  14.10](http://docs.oasis-open.org/office/v1.1/OS/OpenDocument-v1.1-html/OpenDocument-v1.1.html#outline:14.10.List_Style)|
+| prefix| [\<string\>](http://www.w3.org/TR/REC-CSS2/syndata.html#strings)| The prefix is inserted in front of the text.  The prefix contains a number (with any leading or trailing punctuation such as leading and/or trailing parens and/or a trailing period), or a bullet character, or the word "graphic".
+
+
+### Paragraph
 
 Text objects such as those with role paragraph can have per paragraph object attributes as listed in the table below.
-^ Name^ Values^ Comments^ Reference^
-| line-height| normal, [[http://www.w3.org/TR/REC-CSS2/syndata.html#value-def-length|<length>]], [[http://www.w3.org/TR/REC-CSS2/syndata.html#value-def-percentage|<percentage>]]| [[http://www.w3.org/TR/REC-CSS2/syndata.html#value-def-length|<length>]] is zero or positive.  This value should be specified in mm, e.g. 4mm.| [[http://www.w3.org/TR/REC-CSS2/visudet.html#propdef-line-height|CSS2 Specification 10.8.1]]|
-| line-spacing| [[http://www.w3.org/TR/REC-CSS2/syndata.html#value-def-length|<length>]]| [[http://www.w3.org/TR/REC-CSS2/syndata.html#value-def-length|<length>]] is zero or positive.  This value should be specified in mm, e.g. 4mm.| [[http://docs.oasis-open.org/office/v1.1/OS/OpenDocument-v1.1-html/OpenDocument-v1.1.html#outline:15.5.3.Line_Distance|ODF Specification 15.5.3]]|
-| margin-top| [[http://www.w3.org/TR/REC-CSS2/syndata.html#value-def-length|<length>]], [[http://www.w3.org/TR/REC-CSS2/syndata.html#value-def-percentage|<percentage>]]| A typical use of this attribute is to define the margin adjacent to a paragraph but it could be used on any object.  Negative values for the margin property [[http://www.w3.org/TR/REC-CSS2/syndata.html#value-def-length|<length>]] are allowed, but there may be implementation-specific limits.  This value should be specified in mm, e.g. 4mm.| [[http://www.w3.org/TR/REC-CSS2/box.html#propdef-margin-bottom|CSS2 Specification 8.3]]|
-| margin-bottom| [[http://www.w3.org/TR/REC-CSS2/syndata.html#value-def-length|<length>]], [[http://www.w3.org/TR/REC-CSS2/syndata.html#value-def-percentage|<percentage>]]| A typical use of this attribute is to define the margin adjacent to a paragraph but it could be used on any object.  Negative values for the margin property [[http://www.w3.org/TR/REC-CSS2/syndata.html#value-def-length|<length>]] are allowed, but there may be implementation-specific limits.  This value should be specified in mm, e.g. 4mm.| [[http://www.w3.org/TR/REC-CSS2/box.html#propdef-margin-bottom|CSS2 Specification 8.3]]|
-| margin-left| [[http://www.w3.org/TR/REC-CSS2/syndata.html#value-def-length|<length>]], [[http://www.w3.org/TR/REC-CSS2/syndata.html#value-def-percentage|<percentage>]]| A typical use of this attribute is to define the margin adjacent to a paragraph but it could be used on any object.  Negative values for the margin property [[http://www.w3.org/TR/REC-CSS2/syndata.html#value-def-length|<length>]] are allowed, but there may be implementation-specific limits.  This value should be specified in mm, e.g. 4mm.| [[http://www.w3.org/TR/REC-CSS2/box.html#propdef-margin-left|CSS2 Specification 8.3]]|
-| margin-right| [[http://www.w3.org/TR/REC-CSS2/syndata.html#value-def-length|<length>]], [[http://www.w3.org/TR/REC-CSS2/syndata.html#value-def-percentage|<percentage>]]| A typical use of this attribute is to define the margin adjacent to a paragraph but it could be used on any object.  Negative values for the margin property [[http://www.w3.org/TR/REC-CSS2/syndata.html#value-def-length|<length>]] are allowed, but there may be implementation-specific limits.  This value should be specified in mm, e.g. 4mm.| [[http://www.w3.org/TR/REC-CSS2/box.html#propdef-margin-right|CSS2 Specification 8.3]]|
-| tab-stop| tab-stop:position=[[http://www.w3.org/TR/REC-CSS2/syndata.html#value-def-length|<length>]], type=left, center, right, char, char=<character>, leader-text=<character>, leader-style=none, solid, dotted, dash, long-dash, dot-dash, dot-dot-dash, wave| Position must be 0 or positive. char and leader-text are single UNICODE characters.| [[http://docs.oasis-open.org/office/v1.1/OS/OpenDocument-v1.1-html/OpenDocument-v1.1.html#outline:15.5.11.Tab_Stops|ODF Specification 15.5.11]]|
-| text-align| left, right, justify, center| [[http://www.w3.org/TR/REC-CSS2/text.html#propdef-text-align|CSS2 Specification 16.2]]|
-| text-indent| [[http://www.w3.org/TR/REC-CSS2/syndata.html#value-def-length|<length>]]| Negative values for the margin property [[http://www.w3.org/TR/REC-CSS2/syndata.html#value-def-length|<length>]] are allowed, but there may be implementation-specific limits.  This value should be specified in mm, e.g. 4mm.| [[http://www.w3.org/TR/REC-CSS2/text.html#propdef-text-indent|CSS2 Specification 16.1]]|
+
+|Name|Values|Comments|Reference|
+|---|---|---|---|
+| line-height| normal, [\<length\>](http://www.w3.org/TR/REC-CSS2/syndata.html#value-def-length), [\<percentage\>](http://www.w3.org/TR/REC-CSS2/syndata.html#value-def-percentage)| [\<length\>](http://www.w3.org/TR/REC-CSS2/syndata.html#value-def-length) is zero or positive.  This value should be specified in mm, e.g. 4mm.| [CSS2 Specification 10.8.1](http://www.w3.org/TR/REC-CSS2/visudet.html#propdef-line-height)|
+| line-spacing| [\<length\>](http://www.w3.org/TR/REC-CSS2/syndata.html#value-def-length)| [\<length\>](http://www.w3.org/TR/REC-CSS2/syndata.html#value-def-length) is zero or positive.  This value should be specified in mm, e.g. 4mm.| [ODF Specification 15.5.3](http://docs.oasis-open.org/office/v1.1/OS/OpenDocument-v1.1-html/OpenDocument-v1.1.html#outline:15.5.3.Line_Distance)|
+| margin-top| [\<length\>](http://www.w3.org/TR/REC-CSS2/syndata.html#value-def-length), [\<percentage\>](http://www.w3.org/TR/REC-CSS2/syndata.html#value-def-percentage)| A typical use of this attribute is to define the margin adjacent to a paragraph but it could be used on any object.  Negative values for the margin property [\<length\>](http://www.w3.org/TR/REC-CSS2/syndata.html#value-def-length) are allowed, but there may be implementation-specific limits.  This value should be specified in mm, e.g. 4mm.| [CSS2 Specification 8.3](http://www.w3.org/TR/REC-CSS2/box.html#propdef-margin-bottom)|
+| margin-bottom| [\<length\>](http://www.w3.org/TR/REC-CSS2/syndata.html#value-def-length), [\<percentage\>](http://www.w3.org/TR/REC-CSS2/syndata.html#value-def-percentage)| A typical use of this attribute is to define the margin adjacent to a paragraph but it could be used on any object.  Negative values for the margin property [\<length\>](http://www.w3.org/TR/REC-CSS2/syndata.html#value-def-length) are allowed, but there may be implementation-specific limits.  This value should be specified in mm, e.g. 4mm.| [CSS2 Specification 8.3](http://www.w3.org/TR/REC-CSS2/box.html#propdef-margin-bottom)|
+| margin-left| [\<length\>](http://www.w3.org/TR/REC-CSS2/syndata.html#value-def-length), [\<percentage\>](http://www.w3.org/TR/REC-CSS2/syndata.html#value-def-percentage)| A typical use of this attribute is to define the margin adjacent to a paragraph but it could be used on any object.  Negative values for the margin property [\<length\>](http://www.w3.org/TR/REC-CSS2/syndata.html#value-def-length) are allowed, but there may be implementation-specific limits.  This value should be specified in mm, e.g. 4mm.| [CSS2 Specification 8.3](http://www.w3.org/TR/REC-CSS2/box.html#propdef-margin-left)|
+| margin-right| [\<length\>](http://www.w3.org/TR/REC-CSS2/syndata.html#value-def-length), [\<percentage\>](http://www.w3.org/TR/REC-CSS2/syndata.html#value-def-percentage)| A typical use of this attribute is to define the margin adjacent to a paragraph but it could be used on any object.  Negative values for the margin property [\<length\>](http://www.w3.org/TR/REC-CSS2/syndata.html#value-def-length) are allowed, but there may be implementation-specific limits.  This value should be specified in mm, e.g. 4mm.| [CSS2 Specification 8.3](http://www.w3.org/TR/REC-CSS2/box.html#propdef-margin-right)|
+| tab-stop| tab-stop:position=[\<length\>](http://www.w3.org/TR/REC-CSS2/syndata.html#value-def-length), type=left, center, right, char, char=<character>, leader-text=<character>, leader-style=none, solid, dotted, dash, long-dash, dot-dash, dot-dot-dash, wave| Position must be 0 or positive. char and leader-text are single UNICODE characters.| [ODF Specification 15.5.11](http://docs.oasis-open.org/office/v1.1/OS/OpenDocument-v1.1-html/OpenDocument-v1.1.html#outline:15.5.11.Tab_Stops)|
+| text-align| left, right, justify, center| [CSS2 Specification 16.2](http://www.w3.org/TR/REC-CSS2/text.html#propdef-text-align)|
+| text-indent| [\<length\>](http://www.w3.org/TR/REC-CSS2/syndata.html#value-def-length)| Negative values for the margin property [\<length\>](http://www.w3.org/TR/REC-CSS2/syndata.html#value-def-length) are allowed, but there may be implementation-specific limits.  This value should be specified in mm, e.g. 4mm.| [CSS2 Specification 16.1](http://www.w3.org/TR/REC-CSS2/text.html#propdef-text-indent)|
 
 
 

--- a/spec/objectattributes.md
+++ b/spec/objectattributes.md
@@ -1,0 +1,63 @@
+======iaccessible2/objectattributes======
+
+ **Object Attributes**\\
+=====Contents=====
+
+  * [[https://www.linuxfoundation.org/#General_Information|1 General Information]]
+    * [[https://www.linuxfoundation.org/#Referenced_Specifications|1.1 Referenced Specifications]]
+    * [[https://www.linuxfoundation.org/#CSS2_values_information|1.2 CSS2 values information]]
+    * [[https://www.linuxfoundation.org/#Formating|1.3 Formating]]
+  * [[https://www.linuxfoundation.org/#Attributes|2 Attributes]]
+    * [[https://www.linuxfoundation.org/#List|2.1 List]]
+      * [[https://www.linuxfoundation.org/#List_Subattributes|2.1.1 List Subattributes]]
+    * [[https://www.linuxfoundation.org/#Paragraph|2.2 Paragraph]]
+
+===== General Information=====
+==== Referenced Specifications====
+
+  *  [[http://docs.oasis-open.org/office/v1.1/OS/OpenDocument-v1.1-html/OpenDocument-v1.1.html|ODF v1.1]]
+  *  [[http://www.w3.org/TR/REC-CSS2/|CSS2]]
+==== CSS2 values information====
+
+  *  [[http://www.w3.org/TR/REC-CSS2/syndata.html#value-def-length|<length>]]
+  *  [[http://www.w3.org/TR/REC-CSS2/syndata.html#value-def-percentage|<percentage>]]
+  *  [[http://www.w3.org/TR/REC-CSS2/syndata.html#strings|<string>]]
+  *  [[http://www.w3.org/TR/REC-CSS2/syndata.html#q13|<integer>]]
+==== Formating====
+
+  *  The proper format for the attributes is \\  '' "attribute:value;attribute:subattribute=subvalue,subattribute=subvalue;" ''
+  *  These characters need to be escaped with a backslash:  backslash, colon, comma, equals, and semicolon.
+  *  Attribute strings must always end with a semicolon.
+===== Attributes=====
+==== List====
+
+Bulleted and numbered lists have been implemented in two different ways in IAccessible2 implementations.
+
+In versions 2 and later of IBM Lotus Symphony the list items are objects of role IA2_ROLE_PARAGRAPH; each of those paragraph objects implements IAccessible2::attributes; one of the attributes is the list attribute described below.  For these list items IAccessibleText exposes the contents after the non-editable prefix string.  The prefix string is in the form of a bullet character, a numbering prefix string, or an image.  The reason for this separation of access mechanisms is because the caret is movable through the list text but not through the prefix text.
+
+In Firefox the full string including the prefix is provided via IAccessibleText::text and the "auto-generated" text attribute is used for the string of characters representing the list prefix.
+^ Name^ Values^ Comments^ Reference^
+| list| level=[[http://www.w3.org/TR/REC-CSS2/syndata.html#q13|<integer>]], style=[[http://docs.oasis-open.org/office/v1.1/OS/OpenDocument-v1.1-html/OpenDocument-v1.1.html#outline:14.10.3.Bullet_Level_Style|bullet]], [[http://docs.oasis-open.org/office/v1.1/OS/OpenDocument-v1.1-html/OpenDocument-v1.1.html#outline:14.10.2.Number_Level_Style|number]], [[http://docs.oasis-open.org/office/v1.1/OS/OpenDocument-v1.1-html/OpenDocument-v1.1.html#outline:14.10.4.Image_Level_Style|image]], prefix=[[http://www.w3.org/TR/REC-CSS2/syndata.html#strings|<string>]]| [[http://www.w3.org/TR/REC-CSS2/syndata.html#q13|<integer>]] must be positive.| [[http://docs.oasis-open.org/office/v1.1/OS/OpenDocument-v1.1-html/OpenDocument-v1.1.html#outline:14.10.List_Style|ODF Specification  14.10]]|
+=== List Subattributes===
+^ Name^ Values^ Comments^ Reference^
+| level| [[http://www.w3.org/TR/REC-CSS2/syndata.html#q13|<integer>]]| [[http://www.w3.org/TR/REC-CSS2/syndata.html#q13|<integer>]] must be positive.|[[http://docs.oasis-open.org/office/v1.1/OS/OpenDocument-v1.1-html/OpenDocument-v1.1.html#outline:14.10.1.Common_List-Level_Style_Attributes|ODF Specification  14.10.1]]|
+| style| [[http://docs.oasis-open.org/office/v1.1/OS/OpenDocument-v1.1-html/OpenDocument-v1.1.html#outline:14.10.3.Bullet_Level_Style|bullet]], [[http://docs.oasis-open.org/office/v1.1/OS/OpenDocument-v1.1-html/OpenDocument-v1.1.html#outline:14.10.2.Number_Level_Style|number]], [[http://docs.oasis-open.org/office/v1.1/OS/OpenDocument-v1.1-html/OpenDocument-v1.1.html#outline:14.10.4.Image_Level_Style|image]]| Specifies the style of the list.| [[http://docs.oasis-open.org/office/v1.1/OS/OpenDocument-v1.1-html/OpenDocument-v1.1.html#outline:14.10.List_Style|ODF Specification  14.10]]|
+| prefix| [[http://www.w3.org/TR/REC-CSS2/syndata.html#strings|<string>]]| The prefix is inserted in front of the text.  The prefix contains a number (with any leading or trailing punctuation such as leading and/or trailing parens and/or a trailing period), or a bullet character, or the word "graphic".
+
+\\
+==== Paragraph====
+
+Text objects such as those with role paragraph can have per paragraph object attributes as listed in the table below.
+^ Name^ Values^ Comments^ Reference^
+| line-height| normal, [[http://www.w3.org/TR/REC-CSS2/syndata.html#value-def-length|<length>]], [[http://www.w3.org/TR/REC-CSS2/syndata.html#value-def-percentage|<percentage>]]| [[http://www.w3.org/TR/REC-CSS2/syndata.html#value-def-length|<length>]] is zero or positive.  This value should be specified in mm, e.g. 4mm.| [[http://www.w3.org/TR/REC-CSS2/visudet.html#propdef-line-height|CSS2 Specification 10.8.1]]|
+| line-spacing| [[http://www.w3.org/TR/REC-CSS2/syndata.html#value-def-length|<length>]]| [[http://www.w3.org/TR/REC-CSS2/syndata.html#value-def-length|<length>]] is zero or positive.  This value should be specified in mm, e.g. 4mm.| [[http://docs.oasis-open.org/office/v1.1/OS/OpenDocument-v1.1-html/OpenDocument-v1.1.html#outline:15.5.3.Line_Distance|ODF Specification 15.5.3]]|
+| margin-top| [[http://www.w3.org/TR/REC-CSS2/syndata.html#value-def-length|<length>]], [[http://www.w3.org/TR/REC-CSS2/syndata.html#value-def-percentage|<percentage>]]| A typical use of this attribute is to define the margin adjacent to a paragraph but it could be used on any object.  Negative values for the margin property [[http://www.w3.org/TR/REC-CSS2/syndata.html#value-def-length|<length>]] are allowed, but there may be implementation-specific limits.  This value should be specified in mm, e.g. 4mm.| [[http://www.w3.org/TR/REC-CSS2/box.html#propdef-margin-bottom|CSS2 Specification 8.3]]|
+| margin-bottom| [[http://www.w3.org/TR/REC-CSS2/syndata.html#value-def-length|<length>]], [[http://www.w3.org/TR/REC-CSS2/syndata.html#value-def-percentage|<percentage>]]| A typical use of this attribute is to define the margin adjacent to a paragraph but it could be used on any object.  Negative values for the margin property [[http://www.w3.org/TR/REC-CSS2/syndata.html#value-def-length|<length>]] are allowed, but there may be implementation-specific limits.  This value should be specified in mm, e.g. 4mm.| [[http://www.w3.org/TR/REC-CSS2/box.html#propdef-margin-bottom|CSS2 Specification 8.3]]|
+| margin-left| [[http://www.w3.org/TR/REC-CSS2/syndata.html#value-def-length|<length>]], [[http://www.w3.org/TR/REC-CSS2/syndata.html#value-def-percentage|<percentage>]]| A typical use of this attribute is to define the margin adjacent to a paragraph but it could be used on any object.  Negative values for the margin property [[http://www.w3.org/TR/REC-CSS2/syndata.html#value-def-length|<length>]] are allowed, but there may be implementation-specific limits.  This value should be specified in mm, e.g. 4mm.| [[http://www.w3.org/TR/REC-CSS2/box.html#propdef-margin-left|CSS2 Specification 8.3]]|
+| margin-right| [[http://www.w3.org/TR/REC-CSS2/syndata.html#value-def-length|<length>]], [[http://www.w3.org/TR/REC-CSS2/syndata.html#value-def-percentage|<percentage>]]| A typical use of this attribute is to define the margin adjacent to a paragraph but it could be used on any object.  Negative values for the margin property [[http://www.w3.org/TR/REC-CSS2/syndata.html#value-def-length|<length>]] are allowed, but there may be implementation-specific limits.  This value should be specified in mm, e.g. 4mm.| [[http://www.w3.org/TR/REC-CSS2/box.html#propdef-margin-right|CSS2 Specification 8.3]]|
+| tab-stop| tab-stop:position=[[http://www.w3.org/TR/REC-CSS2/syndata.html#value-def-length|<length>]], type=left, center, right, char, char=<character>, leader-text=<character>, leader-style=none, solid, dotted, dash, long-dash, dot-dash, dot-dot-dash, wave| Position must be 0 or positive. char and leader-text are single UNICODE characters.| [[http://docs.oasis-open.org/office/v1.1/OS/OpenDocument-v1.1-html/OpenDocument-v1.1.html#outline:15.5.11.Tab_Stops|ODF Specification 15.5.11]]|
+| text-align| left, right, justify, center| [[http://www.w3.org/TR/REC-CSS2/text.html#propdef-text-align|CSS2 Specification 16.2]]|
+| text-indent| [[http://www.w3.org/TR/REC-CSS2/syndata.html#value-def-length|<length>]]| Negative values for the margin property [[http://www.w3.org/TR/REC-CSS2/syndata.html#value-def-length|<length>]] are allowed, but there may be implementation-specific limits.  This value should be specified in mm, e.g. 4mm.| [[http://www.w3.org/TR/REC-CSS2/text.html#propdef-text-indent|CSS2 Specification 16.1]]|
+
+
+

--- a/spec/objectattributes.md
+++ b/spec/objectattributes.md
@@ -1,3 +1,7 @@
+<!--
+SPDX-License-Identifier: CC-BY-NC-SA-4.0
+-->
+
 # IAccessible2 Object Attributes
 
 ## General Information

--- a/spec/textattributes.md
+++ b/spec/textattributes.md
@@ -1,0 +1,80 @@
+======iaccessible2/textattributes======
+
+ **Text Attributes**
+=====Contents=====
+
+  * [[https://www.linuxfoundation.org/#General_Information|1 General Information]]
+    * [[https://www.linuxfoundation.org/#Referenced_Specifications|1.1 Referenced Specifications]]
+    * [[https://www.linuxfoundation.org/#CSS_2.1_values_information|1.2 CSS 2.1 values information]]
+    * [[https://www.linuxfoundation.org/#Formatting|1.3 Formatting]]
+    * [[https://www.linuxfoundation.org/#Object_Attributes|1.4 Object Attributes]]
+  * [[https://www.linuxfoundation.org/#Attributes|2 Attributes]]
+
+=====General Information=====
+
+
+====Referenced Specifications====
+
+
+
+
+
+  * [[http://www.w3.org/TR/CSS21/|CSS 2.1]]
+  * [[http://www.w3.org/TR/CSS2/|CSS2]]
+  * [[http://tools.ietf.org/html/rfc4646|IETF RFC 4646]]
+  * [[http://tools.ietf.org/html/rfc4647|IETF RFC 4647]]
+  * [[http://docs.oasis-open.org/office/v1.1/OS/OpenDocument-v1.1-html/OpenDocument-v1.1.html|ODF v1.1]]
+  * [[http://www.w3.org/TR/wai-aria|WAI-ARIA 1.0]]
+  * [[http://www.w3.org/TR/xsl11|XSL 1.1]]
+====CSS 2.1 values information====
+
+  * [[http://www.w3.org/TR/CSS21/syndata.html#value-def-color|<color>]]
+  * [[http://www.w3.org/TR/CSS21/syndata.html#numbers|<integer>]]
+  * [[http://www.w3.org/TR/CSS21/syndata.html#value-def-length|<length>]]
+  * [[http://www.w3.org/TR/CSS21/syndata.html#percentage-units|<percentage>]]
+  * [[http://www.w3.org/TR/CSS21/syndata.html#strings|<string>]]
+====Formatting====
+
+
+
+  * The proper format for the attributes is\\  ''"attribute:value;attribute:value,value;"''
+  * The format of ''attribute:value,value;'' is currently only used for the invalid attribute, e.g. ''invalid:spelling,grammar;''
+  * These characters need to be escaped with a backslash: backslash, colon, comma, equals, and semicolon.
+  * Attribute strings must always end with a semicolon, i.e. there needs to be a semicolon at the very end of the string of the full set of attribute:value pairs.
+  * Series of attribute values, as shown in the examples above, must not end with a comma.
+====Object Attributes====
+
+
+
+Some text attributes are on a paragraph by paragraph basis and are documented in the [[:accessibility:iaccessible2:objectattributes|Object Attributes Specification]].
+=====Attributes=====
+
+
+
+The following attributes can change on a character by character basis. They are retrieved via the IAccessibleText::attributes method. If an attribute is not specified and if the table shows that there is a default value, the default value should be assumed.
+^Name^Values^Default^Comments^Reference^
+|auto-generated|true, false|false|This attribute is used in Firefox but not in IBM Lotus Symphony. Symphony uses the list object attribute for bulleted and numbered lists. In Firefox, this attribute's value is "true" for list bullet/numbering prefix text or layout-inserted text such as via the CSS pseudo styles :before or :after.| |
+|background-color|transparent, [[http://www.w3.org/TR/CSS21/syndata.html#value-def-color|<color>]]|transparent|[[http://www.w3.org/TR/CSS21/syndata.html#value-def-color|<color>]] as rgb(n,n,n) where n is 0-255|[[http://www.w3.org/TR/CSS21/colors.html#background-properties|CSS 2.1 Specification 14.2.1]]|
+|color|[[http://www.w3.org/TR/CSS21/syndata.html#value-def-color|<color>]]|rgb(0,0,0)|[[http://www.w3.org/TR/CSS21/syndata.html#value-def-color|<color>]] as rgb(n,n,n) where n is 0-255|[[http://www.w3.org/TR/CSS21/colors.html#colors|CSS 2.1 Specification 14.1]]|
+|font-family|[[http://www.w3.org/TR/CSS21/syndata.html#strings|<string>]]|no default| |[[http://www.w3.org/TR/CSS21/fonts.html#font-family-prop|CSS 2.1 Specification 15.3]]|
+|font-size|[[http://www.w3.org/TR/CSS21/syndata.html#value-def-length|<length>]]|no default|font size in points, e.g. font-size:12pt;\\  \\  Note: When the application's native attribute is not in pts the application accessibility code should convert to pt. The conversion doesn't have to be exact. The intent is to give the user a feel for the size of the text.|[[http://www.w3.org/TR/CSS21/fonts.html#font-size-props|CSS 2.1 Specification 15.7]]|
+|font-style|normal, italic, oblique|normal| |[[http://www.w3.org/TR/CSS21/fonts.html#font-styling|CSS 2.1 Specification 15.4]]|
+|font-weight|normal, bold, [[http://www.w3.org/TR/CSS21/syndata.html#numbers|<integer>]]|normal (400)|100, 200, 300, 400, 500, 600, 700, 800, 900; normal = 400, bold = 700|[[http://www.w3.org/TR/CSS21/fonts.html#font-boldness|CSS 2.1 Specification 15.6]]|
+|invalid|true, false, spelling, grammar|false| |[[http://www.w3.org/TR/wai-aria/#aria-invalid|WAI-ARIA Specification 5.6]]|
+|language|language in IETF [[http://www.ietf.org/rfc/rfc4646.txt|RFC 4646]] format|en-US|Examples are en-US and de-DE.\\ Also refer to [[http://www.w3.org/International/articles/language-tags/|Language tags in HTML and XML]].\\ |[[http://tools.ietf.org/html/rfc4646|IETF RFC 4646]]\\  \\  [[http://tools.ietf.org/html/rfc4647|IETF RFC 4647]]|
+|text-line-through-mode|continuous, skip-white-space|continuous| |[[http://docs.oasis-open.org/office/v1.1/OS/OpenDocument-v1.1-html/OpenDocument-v1.1.html#outline:15.4.34.Text_Line-Through_Word_Mode|ODF Specification 15.4.34]]|
+|text-line-through-style|none, solid, dotted, dash, long-dash, dot-dash, dot-dot-dash, wave|none|Either text-line-through-style or text-line-through-type or both can be used. If text-line-through-type is not used the line is a single line.|[[http://docs.oasis-open.org/office/v1.1/OS/OpenDocument-v1.1-html/OpenDocument-v1.1.html#outline:15.4.7.Line-Through_Style|ODF Specification 15.4.7]]|
+|text-line-through-text|[[http://www.w3.org/TR/CSS21/syndata.html#strings|<string>]]|an empty string|Typical values are / and X, e.g. text-line-through-text:/;|[[http://docs.oasis-open.org/office/v1.1/OS/OpenDocument-v1.1-html/OpenDocument-v1.1.html#outline:15.4.10.Line-Through_Text|ODF Specification 15.4.10]]|
+|text-line-through-type|none, single, double|none|Either text-line-through-type or text-line-through-style or both can be used. If text-line-through-style is not used the line is solid.|[[http://docs.oasis-open.org/office/v1.1/OS/OpenDocument-v1.1-html/OpenDocument-v1.1.html#outline:15.4.6.Line-Through_Type|ODF Specification 15.4.6]]|
+|text-line-through-width|auto, normal, bold, thin, dash, medium, thick, [[http://www.w3.org/TR/CSS21/syndata.html#numbers|<integer>]], [[http://www.w3.org/TR/CSS21/syndata.html#value-def-length|<length>]], [[http://www.w3.org/TR/CSS21/syndata.html#percentage-units|<percentage>]]|auto|[[http://www.w3.org/TR/CSS21/syndata.html#numbers|<integer>]] and [[http://www.w3.org/TR/CSS21/syndata.html#value-def-length|<length>]] must be positive.|[[http://docs.oasis-open.org/office/v1.1/OS/OpenDocument-v1.1-html/OpenDocument-v1.1.html#outline:15.4.8.Line-Through_Width|ODF Specification 15.4.8]]|
+|text-outline|true, false|false| |[[http://docs.oasis-open.org/office/v1.1/OS/OpenDocument-v1.1-html/OpenDocument-v1.1.html#outline:15.4.5.Text_Outline|ODF Specification 15.4.5]]|
+|text-position|baseline, super, sub|baseline|When the text is not positioned on the baseline and the application's native attribute is not specified as super or sub the application should provide the value super when the text is above the baseline and sub when the text is below the baseline.\\ Also consider the case of the html snippet, x<sup>a<sub>i</sub></sup>. A super or sub text attribute refers to the base line of the prior character which in turn may itself be offset from the baseline of the character in front of it.\\ |[[http://www.w3.org/TR/CSS21/visudet.html#propdef-vertical-align|CSS 2.1 Specification 10.8]]|
+|text-shadow|see reference|none|Inherit is not a valid value.\\ Note that this attribute was removed from the CSS2 spec. The link in the reference column is to an archived version of the CSS2 spec.\\ |[[http://www.w3.org/TR/1998/REC-CSS2-19980512/text.html#text-shadow-props|CSS2 Specification 16.3.2]]|
+|text-underline-mode|continuous, skip-white-space|continuous| |[[http://docs.oasis-open.org/office/v1.1/OS/OpenDocument-v1.1-html/OpenDocument-v1.1.html#outline:15.4.33.Text_Underline_Word_Mode|ODF Specification 15.4.33]]|
+|text-underline-style|none, solid, dotted, dash, long-dash, dot-dash, dot-dot-dash, wave|none|Either text-underline-style or text-underline-type or both can be used. If text-underline-type is not used the line is a single line.|[[http://docs.oasis-open.org/office/v1.1/OS/OpenDocument-v1.1-html/OpenDocument-v1.1.html#outline:15.4.29.Underlining_Style|ODF Specification 15.4.29]]|
+|text-underline-type|none, single, double|none|Either text-underline-type or text-underline-style or both can be used. If text-underline-style is not used the line is solid.|[[http://docs.oasis-open.org/office/v1.1/OS/OpenDocument-v1.1-html/OpenDocument-v1.1.html#outline:15.4.28.Underlining_Type|ODF Specification 15.4.28]]|
+|text-underline-width|auto, normal, bold, thin, dash, medium, thick, [[http://www.w3.org/TR/CSS21/syndata.html#numbers|<integer>]], [[http://www.w3.org/TR/CSS21/syndata.html#value-def-length|<length>]], [[http://www.w3.org/TR/CSS21/syndata.html#percentage-units|<percentage>]]|auto|[[http://www.w3.org/TR/CSS21/syndata.html#numbers|<integer>]] and [[http://www.w3.org/TR/CSS21/syndata.html#value-def-length|<length>]] must be positive.|[[http://docs.oasis-open.org/office/v1.1/OS/OpenDocument-v1.1-html/OpenDocument-v1.1.html#outline:15.4.30.Underling_Width|ODF Specification 15.4.30]]|
+|writing-mode|lr, rl, tb|lr|tb is top-to-bottom, i.e. text flows from top-to-bottom then left-to-right.|[[http://www.w3.org/TR/xsl11/#writing-mode|XSL 1.1 Specification 7.29.7]]|
+
+
+

--- a/spec/textattributes.md
+++ b/spec/textattributes.md
@@ -1,3 +1,7 @@
+<!--
+SPDX-License-Identifier: CC-BY-NC-SA-4.0
+-->
+
 # IAccessible2 Text Attributes
 
 ## General Information

--- a/spec/textattributes.md
+++ b/spec/textattributes.md
@@ -1,80 +1,62 @@
-======iaccessible2/textattributes======
+# IAccessible2 Text Attributes
 
- **Text Attributes**
-=====Contents=====
+## General Information
 
-  * [[https://www.linuxfoundation.org/#General_Information|1 General Information]]
-    * [[https://www.linuxfoundation.org/#Referenced_Specifications|1.1 Referenced Specifications]]
-    * [[https://www.linuxfoundation.org/#CSS_2.1_values_information|1.2 CSS 2.1 values information]]
-    * [[https://www.linuxfoundation.org/#Formatting|1.3 Formatting]]
-    * [[https://www.linuxfoundation.org/#Object_Attributes|1.4 Object Attributes]]
-  * [[https://www.linuxfoundation.org/#Attributes|2 Attributes]]
+### Referenced Specifications
 
-=====General Information=====
+  * [CSS 2.1](http://www.w3.org/TR/CSS21/)
+  * [CSS2](http://www.w3.org/TR/CSS2/)
+  * [IETF RFC 4646](http://tools.ietf.org/html/rfc4646)
+  * [IETF RFC 4647](http://tools.ietf.org/html/rfc4647)
+  * [ODF v1.1](http://docs.oasis-open.org/office/v1.1/OS/OpenDocument-v1.1-html/OpenDocument-v1.1.html)
+  * [WAI-ARIA 1.0](http://www.w3.org/TR/wai-aria)
+  * [XSL 1.1](http://www.w3.org/TR/xsl11)
 
+### CSS 2.1 values information
 
-====Referenced Specifications====
+  * [\<color\>](http://www.w3.org/TR/CSS21/syndata.html#value-def-color)
+  * [\<integer\>](http://www.w3.org/TR/CSS21/syndata.html#numbers)
+  * [\<length\>](http://www.w3.org/TR/CSS21/syndata.html#value-def-length)
+  * [\<percentage\>](http://www.w3.org/TR/CSS21/syndata.html#percentage-units)
+  * [\<string\>](http://www.w3.org/TR/CSS21/syndata.html#strings)
 
+### Formatting
 
-
-
-
-  * [[http://www.w3.org/TR/CSS21/|CSS 2.1]]
-  * [[http://www.w3.org/TR/CSS2/|CSS2]]
-  * [[http://tools.ietf.org/html/rfc4646|IETF RFC 4646]]
-  * [[http://tools.ietf.org/html/rfc4647|IETF RFC 4647]]
-  * [[http://docs.oasis-open.org/office/v1.1/OS/OpenDocument-v1.1-html/OpenDocument-v1.1.html|ODF v1.1]]
-  * [[http://www.w3.org/TR/wai-aria|WAI-ARIA 1.0]]
-  * [[http://www.w3.org/TR/xsl11|XSL 1.1]]
-====CSS 2.1 values information====
-
-  * [[http://www.w3.org/TR/CSS21/syndata.html#value-def-color|<color>]]
-  * [[http://www.w3.org/TR/CSS21/syndata.html#numbers|<integer>]]
-  * [[http://www.w3.org/TR/CSS21/syndata.html#value-def-length|<length>]]
-  * [[http://www.w3.org/TR/CSS21/syndata.html#percentage-units|<percentage>]]
-  * [[http://www.w3.org/TR/CSS21/syndata.html#strings|<string>]]
-====Formatting====
-
-
-
-  * The proper format for the attributes is\\  ''"attribute:value;attribute:value,value;"''
-  * The format of ''attribute:value,value;'' is currently only used for the invalid attribute, e.g. ''invalid:spelling,grammar;''
+  * The proper format for the attributes is `"attribute:value;attribute:value,value;"`
+  * The format of `attribute:value,value;` is currently only used for the invalid attribute, e.g. `invalid:spelling,grammar;`
   * These characters need to be escaped with a backslash: backslash, colon, comma, equals, and semicolon.
   * Attribute strings must always end with a semicolon, i.e. there needs to be a semicolon at the very end of the string of the full set of attribute:value pairs.
   * Series of attribute values, as shown in the examples above, must not end with a comma.
-====Object Attributes====
 
+### Object Attributes
 
+Some text attributes are on a paragraph by paragraph basis and are documented in the [Object Attributes Specification](./objectattributes.md).
 
-Some text attributes are on a paragraph by paragraph basis and are documented in the [[:accessibility:iaccessible2:objectattributes|Object Attributes Specification]].
-=====Attributes=====
-
-
+## Attributes
 
 The following attributes can change on a character by character basis. They are retrieved via the IAccessibleText::attributes method. If an attribute is not specified and if the table shows that there is a default value, the default value should be assumed.
-^Name^Values^Default^Comments^Reference^
+
+|Name|Values|Default|Comments|Reference|
+|---|---|---|---|---|
 |auto-generated|true, false|false|This attribute is used in Firefox but not in IBM Lotus Symphony. Symphony uses the list object attribute for bulleted and numbered lists. In Firefox, this attribute's value is "true" for list bullet/numbering prefix text or layout-inserted text such as via the CSS pseudo styles :before or :after.| |
-|background-color|transparent, [[http://www.w3.org/TR/CSS21/syndata.html#value-def-color|<color>]]|transparent|[[http://www.w3.org/TR/CSS21/syndata.html#value-def-color|<color>]] as rgb(n,n,n) where n is 0-255|[[http://www.w3.org/TR/CSS21/colors.html#background-properties|CSS 2.1 Specification 14.2.1]]|
-|color|[[http://www.w3.org/TR/CSS21/syndata.html#value-def-color|<color>]]|rgb(0,0,0)|[[http://www.w3.org/TR/CSS21/syndata.html#value-def-color|<color>]] as rgb(n,n,n) where n is 0-255|[[http://www.w3.org/TR/CSS21/colors.html#colors|CSS 2.1 Specification 14.1]]|
-|font-family|[[http://www.w3.org/TR/CSS21/syndata.html#strings|<string>]]|no default| |[[http://www.w3.org/TR/CSS21/fonts.html#font-family-prop|CSS 2.1 Specification 15.3]]|
-|font-size|[[http://www.w3.org/TR/CSS21/syndata.html#value-def-length|<length>]]|no default|font size in points, e.g. font-size:12pt;\\  \\  Note: When the application's native attribute is not in pts the application accessibility code should convert to pt. The conversion doesn't have to be exact. The intent is to give the user a feel for the size of the text.|[[http://www.w3.org/TR/CSS21/fonts.html#font-size-props|CSS 2.1 Specification 15.7]]|
-|font-style|normal, italic, oblique|normal| |[[http://www.w3.org/TR/CSS21/fonts.html#font-styling|CSS 2.1 Specification 15.4]]|
-|font-weight|normal, bold, [[http://www.w3.org/TR/CSS21/syndata.html#numbers|<integer>]]|normal (400)|100, 200, 300, 400, 500, 600, 700, 800, 900; normal = 400, bold = 700|[[http://www.w3.org/TR/CSS21/fonts.html#font-boldness|CSS 2.1 Specification 15.6]]|
-|invalid|true, false, spelling, grammar|false| |[[http://www.w3.org/TR/wai-aria/#aria-invalid|WAI-ARIA Specification 5.6]]|
-|language|language in IETF [[http://www.ietf.org/rfc/rfc4646.txt|RFC 4646]] format|en-US|Examples are en-US and de-DE.\\ Also refer to [[http://www.w3.org/International/articles/language-tags/|Language tags in HTML and XML]].\\ |[[http://tools.ietf.org/html/rfc4646|IETF RFC 4646]]\\  \\  [[http://tools.ietf.org/html/rfc4647|IETF RFC 4647]]|
-|text-line-through-mode|continuous, skip-white-space|continuous| |[[http://docs.oasis-open.org/office/v1.1/OS/OpenDocument-v1.1-html/OpenDocument-v1.1.html#outline:15.4.34.Text_Line-Through_Word_Mode|ODF Specification 15.4.34]]|
-|text-line-through-style|none, solid, dotted, dash, long-dash, dot-dash, dot-dot-dash, wave|none|Either text-line-through-style or text-line-through-type or both can be used. If text-line-through-type is not used the line is a single line.|[[http://docs.oasis-open.org/office/v1.1/OS/OpenDocument-v1.1-html/OpenDocument-v1.1.html#outline:15.4.7.Line-Through_Style|ODF Specification 15.4.7]]|
-|text-line-through-text|[[http://www.w3.org/TR/CSS21/syndata.html#strings|<string>]]|an empty string|Typical values are / and X, e.g. text-line-through-text:/;|[[http://docs.oasis-open.org/office/v1.1/OS/OpenDocument-v1.1-html/OpenDocument-v1.1.html#outline:15.4.10.Line-Through_Text|ODF Specification 15.4.10]]|
-|text-line-through-type|none, single, double|none|Either text-line-through-type or text-line-through-style or both can be used. If text-line-through-style is not used the line is solid.|[[http://docs.oasis-open.org/office/v1.1/OS/OpenDocument-v1.1-html/OpenDocument-v1.1.html#outline:15.4.6.Line-Through_Type|ODF Specification 15.4.6]]|
-|text-line-through-width|auto, normal, bold, thin, dash, medium, thick, [[http://www.w3.org/TR/CSS21/syndata.html#numbers|<integer>]], [[http://www.w3.org/TR/CSS21/syndata.html#value-def-length|<length>]], [[http://www.w3.org/TR/CSS21/syndata.html#percentage-units|<percentage>]]|auto|[[http://www.w3.org/TR/CSS21/syndata.html#numbers|<integer>]] and [[http://www.w3.org/TR/CSS21/syndata.html#value-def-length|<length>]] must be positive.|[[http://docs.oasis-open.org/office/v1.1/OS/OpenDocument-v1.1-html/OpenDocument-v1.1.html#outline:15.4.8.Line-Through_Width|ODF Specification 15.4.8]]|
-|text-outline|true, false|false| |[[http://docs.oasis-open.org/office/v1.1/OS/OpenDocument-v1.1-html/OpenDocument-v1.1.html#outline:15.4.5.Text_Outline|ODF Specification 15.4.5]]|
-|text-position|baseline, super, sub|baseline|When the text is not positioned on the baseline and the application's native attribute is not specified as super or sub the application should provide the value super when the text is above the baseline and sub when the text is below the baseline.\\ Also consider the case of the html snippet, x<sup>a<sub>i</sub></sup>. A super or sub text attribute refers to the base line of the prior character which in turn may itself be offset from the baseline of the character in front of it.\\ |[[http://www.w3.org/TR/CSS21/visudet.html#propdef-vertical-align|CSS 2.1 Specification 10.8]]|
-|text-shadow|see reference|none|Inherit is not a valid value.\\ Note that this attribute was removed from the CSS2 spec. The link in the reference column is to an archived version of the CSS2 spec.\\ |[[http://www.w3.org/TR/1998/REC-CSS2-19980512/text.html#text-shadow-props|CSS2 Specification 16.3.2]]|
-|text-underline-mode|continuous, skip-white-space|continuous| |[[http://docs.oasis-open.org/office/v1.1/OS/OpenDocument-v1.1-html/OpenDocument-v1.1.html#outline:15.4.33.Text_Underline_Word_Mode|ODF Specification 15.4.33]]|
-|text-underline-style|none, solid, dotted, dash, long-dash, dot-dash, dot-dot-dash, wave|none|Either text-underline-style or text-underline-type or both can be used. If text-underline-type is not used the line is a single line.|[[http://docs.oasis-open.org/office/v1.1/OS/OpenDocument-v1.1-html/OpenDocument-v1.1.html#outline:15.4.29.Underlining_Style|ODF Specification 15.4.29]]|
-|text-underline-type|none, single, double|none|Either text-underline-type or text-underline-style or both can be used. If text-underline-style is not used the line is solid.|[[http://docs.oasis-open.org/office/v1.1/OS/OpenDocument-v1.1-html/OpenDocument-v1.1.html#outline:15.4.28.Underlining_Type|ODF Specification 15.4.28]]|
-|text-underline-width|auto, normal, bold, thin, dash, medium, thick, [[http://www.w3.org/TR/CSS21/syndata.html#numbers|<integer>]], [[http://www.w3.org/TR/CSS21/syndata.html#value-def-length|<length>]], [[http://www.w3.org/TR/CSS21/syndata.html#percentage-units|<percentage>]]|auto|[[http://www.w3.org/TR/CSS21/syndata.html#numbers|<integer>]] and [[http://www.w3.org/TR/CSS21/syndata.html#value-def-length|<length>]] must be positive.|[[http://docs.oasis-open.org/office/v1.1/OS/OpenDocument-v1.1-html/OpenDocument-v1.1.html#outline:15.4.30.Underling_Width|ODF Specification 15.4.30]]|
-|writing-mode|lr, rl, tb|lr|tb is top-to-bottom, i.e. text flows from top-to-bottom then left-to-right.|[[http://www.w3.org/TR/xsl11/#writing-mode|XSL 1.1 Specification 7.29.7]]|
-
-
-
+|background-color|transparent, [\<color\>](http://www.w3.org/TR/CSS21/syndata.html#value-def-color)|transparent|[\<color\>](http://www.w3.org/TR/CSS21/syndata.html#value-def-color) as rgb(n,n,n) where n is 0-255|[CSS 2.1 Specification 14.2.1](http://www.w3.org/TR/CSS21/colors.html#background-properties)
+|color|[\<color\>](http://www.w3.org/TR/CSS21/syndata.html#value-def-color)|rgb(0,0,0)|[\<color\>](http://www.w3.org/TR/CSS21/syndata.html#value-def-color) as rgb(n,n,n) where n is 0-255|[CSS 2.1 Specification 14.1](http://www.w3.org/TR/CSS21/colors.html#colors)
+|font-family|[\<string\>](http://www.w3.org/TR/CSS21/syndata.html#strings)|no default| |[CSS 2.1 Specification 15.3](http://www.w3.org/TR/CSS21/fonts.html#font-family-prop)|
+|font-size|[\<length\>](http://www.w3.org/TR/CSS21/syndata.html#value-def-length)|no default|font size in points, e.g. font-size:12pt;<br/><br/>Note: When the application's native attribute is not in pts the application accessibility code should convert to pt. The conversion doesn't have to be exact. The intent is to give the user a feel for the size of the text.|[CSS 2.1 Specification 15.7](http://www.w3.org/TR/CSS21/fonts.html#font-size-props)|
+|font-style|normal, italic, oblique|normal| |[CSS 2.1 Specification 15.4](http://www.w3.org/TR/CSS21/fonts.html#font-styling)|
+|font-weight|normal, bold, [\<integer\>](http://www.w3.org/TR/CSS21/syndata.html#numbers)|normal (400)|100, 200, 300, 400, 500, 600, 700, 800, 900; normal = 400, bold = 700|[CSS 2.1 Specification 15.6](http://www.w3.org/TR/CSS21/fonts.html#font-boldness)|
+|invalid|true, false, spelling, grammar|false| |[WAI-ARIA Specification 5.6](http://www.w3.org/TR/wai-aria/#aria-invalid)|
+|language|language in IETF [RFC 4646](http://www.ietf.org/rfc/rfc4646.txt) format|en-US|Examples are en-US and de-DE.<br/>Also refer to [Language tags in HTML and XML](http://www.w3.org/International/articles/language-tags/).|[IETF RFC 4646](http://tools.ietf.org/html/rfc4646)<br/><br/>[IETF RFC 4647](http://tools.ietf.org/html/rfc4647)|
+|text-line-through-mode|continuous, skip-white-space|continuous| |[ODF Specification 15.4.34](http://docs.oasis-open.org/office/v1.1/OS/OpenDocument-v1.1-html/OpenDocument-v1.1.html#outline:15.4.34.Text_Line-Through_Word_Mode)|
+|text-line-through-style|none, solid, dotted, dash, long-dash, dot-dash, dot-dot-dash, wave|none|Either text-line-through-style or text-line-through-type or both can be used. If text-line-through-type is not used the line is a single line.|[ODF Specification 15.4.7](http://docs.oasis-open.org/office/v1.1/OS/OpenDocument-v1.1-html/OpenDocument-v1.1.html#outline:15.4.7.Line-Through_Style)|
+|text-line-through-text|[\<string\>](http://www.w3.org/TR/CSS21/syndata.html#strings)|an empty string|Typical values are / and X, e.g. text-line-through-text:/;|[ODF Specification 15.4.10](http://docs.oasis-open.org/office/v1.1/OS/OpenDocument-v1.1-html/OpenDocument-v1.1.html#outline:15.4.10.Line-Through_Text)|
+|text-line-through-type|none, single, double|none|Either text-line-through-type or text-line-through-style or both can be used. If text-line-through-style is not used the line is solid.|[ODF Specification 15.4.6](http://docs.oasis-open.org/office/v1.1/OS/OpenDocument-v1.1-html/OpenDocument-v1.1.html#outline:15.4.6.Line-Through_Type)|
+|text-line-through-width|auto, normal, bold, thin, dash, medium, thick, [\<integer\>](http://www.w3.org/TR/CSS21/syndata.html#numbers), [\<length\>](http://www.w3.org/TR/CSS21/syndata.html#value-def-length), [\<percentage\>](http://www.w3.org/TR/CSS21/syndata.html#percentage-units)|auto|[\<integer\>](http://www.w3.org/TR/CSS21/syndata.html#numbers) and [\<length\>](http://www.w3.org/TR/CSS21/syndata.html#value-def-length) must be positive.|[ODF Specification 15.4.8](http://docs.oasis-open.org/office/v1.1/OS/OpenDocument-v1.1-html/OpenDocument-v1.1.html#outline:15.4.8.Line-Through_Width)|
+|text-outline|true, false|false| |[ODF Specification 15.4.5](http://docs.oasis-open.org/office/v1.1/OS/OpenDocument-v1.1-html/OpenDocument-v1.1.html#outline:15.4.5.Text_Outline)|
+|text-position|baseline, super, sub|baseline|When the text is not positioned on the baseline and the application's native attribute is not specified as super or sub the application should provide the value super when the text is above the baseline and sub when the text is below the baseline.<br/>Also consider the case of the html snippet, x<sup>a<sub>i</sub></sup>. A super or sub text attribute refers to the base line of the prior character which in turn may itself be offset from the baseline of the character in front of it.|[CSS 2.1 Specification 10.8](http://www.w3.org/TR/CSS21/visudet.html#propdef-vertical-align)|
+|text-shadow|see reference|none|Inherit is not a valid value.<br/> Note that this attribute was removed from the CSS2 spec. The link in the reference column is to an archived version of the CSS2 spec.|[CSS2 Specification 16.3.2](http://www.w3.org/TR/1998/REC-CSS2-19980512/text.html#text-shadow-props)|
+|text-underline-mode|continuous, skip-white-space|continuous| |[ODF Specification 15.4.33](http://docs.oasis-open.org/office/v1.1/OS/OpenDocument-v1.1-html/OpenDocument-v1.1.html#outline:15.4.33.Text_Underline_Word_Mode)|
+|text-underline-style|none, solid, dotted, dash, long-dash, dot-dash, dot-dot-dash, wave|none|Either text-underline-style or text-underline-type or both can be used. If text-underline-type is not used the line is a single line.|[ODF Specification 15.4.29](http://docs.oasis-open.org/office/v1.1/OS/OpenDocument-v1.1-html/OpenDocument-v1.1.html#outline:15.4.29.Underlining_Style)|
+|text-underline-type|none, single, double|none|Either text-underline-type or text-underline-style or both can be used. If text-underline-style is not used the line is solid.|[ODF Specification 15.4.28](http://docs.oasis-open.org/office/v1.1/OS/OpenDocument-v1.1-html/OpenDocument-v1.1.html#outline:15.4.28.Underlining_Type)|
+|text-underline-width|auto, normal, bold, thin, dash, medium, thick, [\<integer\>](http://www.w3.org/TR/CSS21/syndata.html#numbers), [\<length\>](http://www.w3.org/TR/CSS21/syndata.html#value-def-length), [\<percentage\>](http://www.w3.org/TR/CSS21/syndata.html#percentage-units)|auto|[\<integer\>](http://www.w3.org/TR/CSS21/syndata.html#numbers) and [\<length\>](http://www.w3.org/TR/CSS21/syndata.html#value-def-length) must be positive.|[ODF Specification 15.4.30](http://docs.oasis-open.org/office/v1.1/OS/OpenDocument-v1.1-html/OpenDocument-v1.1.html#outline:15.4.30.Underling_Width)|
+|writing-mode|lr, rl, tb|lr|tb is top-to-bottom, i.e. text flows from top-to-bottom then left-to-right.|[XSL 1.1 Specification 7.29.7](http://www.w3.org/TR/xsl11/#writing-mode)|


### PR DESCRIPTION
As requested in #24, import the text and object attributes specifications from the corresponding Linux Foundation  wiki pages and convert them to Markdown.

See the individual commits in the PR for more details.

Follow-up changes (like adapting the links to those specs) are planned for follow-up PRs.

Fixes #24.