### PR TITLE
Update links to text/obj attrs to the ones in this repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,5 @@ in MSAA while also providing an Assistive Technology (AT) access to rich documen
 The additional functionality includes support for rich text, tables, spreadsheets, Web 2.0 applications, and other
 large mainstream applications.
 
-# Useful links
-* [Object attributes](https://wiki.linuxfoundation.org/accessibility/iaccessible2/objectattributes) former references
-* [Text attributes](https://wiki.linuxfoundation.org/accessibility/iaccessible2/textattributes) former references
-
 # Build ia2_api_all.idl for your project
 Run ```concatidl.sh```

--- a/api/Accessible2_2.idl
+++ b/api/Accessible2_2.idl
@@ -77,7 +77,7 @@ interface IAccessible2_2 : IAccessible2
    @retval E_INVALIDARG if bad [in] passed.
    @note The output value is a VARIANT.  Typically it will be a VT_BSTR, but there
      are some cases where it will be a VT_I4 or VT_BOOL.  Refer to the <a href=
-     "https://wiki.linuxfoundation.org/accessibility/iaccessible2/objectattributes">
+     "https://github.com/LinuxA11y/IAccessible2/blob/master/spec/objectattributes.md">
      Object Attributes specification</a> for more information.
   */
   [propget] HRESULT attribute

--- a/api/AccessibleText.idl
+++ b/api/AccessibleText.idl
@@ -181,8 +181,8 @@ interface IAccessibleText : IUnknown
     attributes match those of offset. (0 based)
    @param [out] textAttributes  
     A string of attributes describing the text.  The attributes are described in the
-    <a href="https://wiki.linuxfoundation.org/accessibility/iaccessible2/textattributes">
-    text attributes specification</a> on the %IAccessible2 web site.
+    <a href="https://github.com/LinuxA11y/IAccessible2/blob/master/spec/textattributes.md">
+    text attributes specification</a>.
    @retval S_OK
    @retval S_FALSE if there is nothing to return, [out] values are 0s and NULL respectively 
    @retval E_INVALIDARG if bad [in] passed


### PR DESCRIPTION
The text and object attribute specifications are now maintained in this repository (see issue #24, PR #27).

Therefore, update links to use these instead of the ones in the Linux Foundation wiki and drop additional references to the latter from the README.