### PR TITLE
Add an "id" object attribute

### DIFF
--- a/spec/objectattributes.md
+++ b/spec/objectattributes.md
@@ -26,6 +26,12 @@ SPDX-License-Identifier: CC-BY-NC-SA-4.0
 
 ## Attributes
 
+### General
+
+|Name|Values|Comments|Reference|
+|---|---|---|---|
+| id|[\<string\>](http://www.w3.org/TR/REC-CSS2/syndata.html#strings)|Unique identifier for the object specified by the author. This identifier remains the same across different sessions of the same application, regardless of the UI language.|[HTML5: Edition for Web Authors, section 3.2.3.1](https://www.w3.org/TR/2011/WD-html5-author-20110809/global-attributes.html#the-id-attribute)|
+
 ### List
 
 Bulleted and numbered lists have been implemented in two different ways in IAccessible2 implementations.


### PR DESCRIPTION
This attribute can be used to provide a reliable and locale-independent way to identify a particular object.

It is already used in practice by e.g. Firefox to report the HTML "id" attribute, e.g. in a document like this

    <html>
        <body>
            <p id="somepara">This is a paragraph</p>
        </body>

    </html>

Showing it in NVDA's Python console:

    >>> focus.role
    <Role.DOCUMENT: 52>
    >>> focus.childCount
    1
    >>> paragraph = focus.children[0]
    >>> paragraph.role
    <Role.PARAGRAPH: 47>
    >>> paragraph.IAccessibleObject.attributes
    'id:somepara;tag:p;display:block;'

It's also used for non-web UI elements, e.g.
the URL/search bar in Firefox 129 has an
"id:urlbar-input" attribute set.

Comparable concepts in other platform accessibility APIs:

* Linux/AT-SPI2: `AccessibleId` property [1]
* Windows/UIA: `UIA_AutomationIdPropertyId` [2]
* macOS/NSAccessibility: `accessibilityIdentifier` [3]

[4] describes another use case relying on reliable identification of UI elements by a screen reader.

[1] https://gitlab.gnome.org/GNOME/at-spi2-core/-/blob/6d01d2f20672ed50f9360c53d5fab021c7c57ab9/xml/Accessible.xml#L69-78
[2] https://learn.microsoft.com/en-us/windows/win32/winauto/uiauto-automation-element-propids
[3] https://developer.apple.com/documentation/appkit/nsaccessibility/1535023-accessibilityidentifier
[4] https://bugs.documentfoundation.org/show_bug.cgi?id=155447